### PR TITLE
Bug fixes, mostly for handling Windows paths

### DIFF
--- a/cmd/restic/cmd_sync.go
+++ b/cmd/restic/cmd_sync.go
@@ -32,7 +32,7 @@ WARNING: Files in the target directory that are not in the snapshot will be dele
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var t tomb.Tomb
-		term := termstatus.New(globalOptions.stdout, globalOptions.stderr, globalOptions.Quiet)
+		term := termstatus.New(globalOptions.stdout, globalOptions.stderr, true)
 		t.Go(func() error { term.Run(t.Context(globalOptions.ctx)); return nil })
 
 		err := runSync(syncOptions, globalOptions, term, args)
@@ -142,8 +142,6 @@ func runSync(opts SyncOptions, gopts GlobalOptions, term *termstatus.Terminal, a
 	}
 
 	p := ui.NewBackup(term, gopts.verbosity)
-	// Hack to disable status line as it causes problems by listing every file
-	p.MinUpdatePause = time.Hour
 
 	// use the terminal for stdout/stderr
 	prevStdout, prevStderr := gopts.stdout, gopts.stderr


### PR DESCRIPTION
These changes:
* Fix directory deletion selection logic
* "Disable" status line by setting it to only output once an hour - so, hopefully, not at all... - as it caused problems on Windows and we weren't using it anyway
* Correct logic for selecting files to get and delete with Windows paths within the filter method
* Adds a note explaining the hard-coded "/" in deleteFilesAndDirectories which remains as our lookup tables all use "/"